### PR TITLE
Added fix to wait if new instances of dataloader were declared during the processing

### DIFF
--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -263,6 +263,11 @@ class DataLoader
                 $dataLoader->process();
             }
         }
+
+        // If new dataloaders were instanciated in the meantime, wait again !
+        if (count($dataLoaders) != count(self::$instances)) {
+            self::awaitInstances();
+        }
     }
 
     private function getCacheKeyFromKey($key)


### PR DESCRIPTION
This fix solves the `awaitInstances` method for cases like this : 

```
$dataloader->load(1)->then(function () {
    $subLoader = new DataLoader(...);
    $subLoader->load(2);
});
```

Without the fix, `awaitInstances()` would stop on the first dataloader, ignoring the second one.