### PR TITLE
Make it possible to call key functions when extending Dataloader

### DIFF
--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -270,7 +270,12 @@ class DataLoader
         }
     }
 
-    private function getCacheKeyFromKey($key)
+    /**
+     * @param $key
+     *
+     * @return mixed
+     */
+    protected function getCacheKeyFromKey($key)
     {
         $cacheKeyFn = $this->options->getCacheKeyFn();
         $cacheKey = $cacheKeyFn ? $cacheKeyFn($key) : $key;
@@ -278,7 +283,11 @@ class DataLoader
         return $cacheKey;
     }
 
-    private function checkKey($key, $method)
+    /**
+     * @param $key
+     * @param $method
+     */
+    protected function checkKey($key, $method)
     {
         if (null === $key) {
             throw new \InvalidArgumentException(


### PR DESCRIPTION
We might need to call `getCacheKeyFromKey` and `checkKey` when extending the `Dataloader` class, in order to have homogeneous keys.

Here is an exemple:

```
    public function load($key)
    {
        $cacheItem = $this->primeCache->getItem($this->getCacheKeyFromKey($key));

        if (!$cacheItem->isHit()) {
            $promise = parent::load($key);
            if ($promise instanceof Promise) {
                $promise->then(function ($value) use ($key) {
                    $this->prime($key, $value);
                });
            }
            return $promise;
        } else {
            return $cacheItem->get();
        }
    }
```