### PR TITLE
Optimize `DataLoader::await` method

### DIFF
--- a/tests/AbuseTest.php
+++ b/tests/AbuseTest.php
@@ -111,7 +111,7 @@ class AbuseTest extends TestCase
      */
     public function testAwaitWithoutNoInstance()
     {
-        DataLoader::await();
+        DataLoader::await(self::$promiseAdapter->create());
     }
 
     /**

--- a/tests/DataLoadTest.php
+++ b/tests/DataLoadTest.php
@@ -809,6 +809,38 @@ class DataLoadTest extends TestCase
         $this->assertTrue($secondComplete);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAwaitShouldReturnTheValueOfFulfilledPromiseWithoutNeedingActiveDataLoaderInstance()
+    {
+        $expectedValue = 'Ok!';
+        $value = DataLoader::await(self::$promiseAdapter->createFulfilled($expectedValue));
+
+        $this->assertEquals($expectedValue, $value);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAwaitShouldReturnTheRejectReasonOfRejectedPromiseWithoutNeedingActiveDataLoaderInstance()
+    {
+        $expectedException = new \Exception('Rejected!');
+        $exception = DataLoader::await(self::$promiseAdapter->createRejected($expectedException), false);
+
+        $this->assertEquals($expectedException, $exception);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Rejected!
+     * @runInSeparateProcess
+     */
+    public function testAwaitShouldThrowTheRejectReasonOfRejectedPromiseWithoutNeedingActiveDataLoaderInstance()
+    {
+        DataLoader::await(self::$promiseAdapter->createRejected(new \Exception('Rejected!')));
+    }
+
     public function cacheKey($key)
     {
         $cacheKey = [];


### PR DESCRIPTION
`DataLoader::await` first tries to get the fulfilled value
or the rejected reason directly from the promise
otherwise calls promise adapter `await`
to complete promise.
Now `DataLoader::await` will not throw "no active
dataLoader instance" exception when Promise entry is null.