### PR TITLE
Fixed ignored instances when added during await()

### DIFF
--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -290,7 +290,7 @@ class DataLoader
 
             foreach ($dataLoaders as $dataLoader) {
                 if (!$dataLoader || !$dataLoader->needProcess()) {
-                    $wait = false;
+                    $wait |= false;
                     continue;
                 }
                 $wait = true;

--- a/tests/DataLoadTest.php
+++ b/tests/DataLoadTest.php
@@ -803,6 +803,11 @@ class DataLoadTest extends TestCase
             return self::$promiseAdapter->createAll(['A']);
         }, self::$promiseAdapter);
 
+        // This tests that an idling dataloader do not cause the others to be skipped.
+        $third = new DataLoader(function () {
+            // noop
+        }, self::$promiseAdapter);
+
         DataLoader::await($first->load('A'));
 
         $this->assertTrue($firstComplete);


### PR DESCRIPTION
This reproduces the fix of https://github.com/overblog/dataloader-php/pull/8 for the new `await()` of the `0.5.0` version.