### PR TITLE
Throw/Unwrap PHP7 \Error in await()

### DIFF
--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -235,7 +235,7 @@ class DataLoader implements DataLoaderInterface
             //Promise is completed?
             if ($isPromiseCompleted) {
                 // rejected ?
-                if ($rejectedReason instanceof \Exception) {
+                if ($rejectedReason instanceof \Exception || (interface_exists('\Throwable') && $rejectedReason instanceof \Throwable)) {
                     if (!$unwrap) {
                         return $rejectedReason;
                     }

--- a/tests/DataLoadTest.php
+++ b/tests/DataLoadTest.php
@@ -846,13 +846,34 @@ class DataLoadTest extends TestCase
         DataLoader::await(self::$promiseAdapter->createRejected(new \Exception('Rejected!')));
     }
 
+    /**
+     * @runInSeparateProcess
+     *
+     * We cannot use the standard expectedException annotations here since the class does not exist in PHP5.
+     */
+    public function testAwaitShouldThrowThrowable()
+    {
+        if (PHP_MAJOR_VERSION >= 7) {
+            try {
+                DataLoader::await(self::$promiseAdapter->createRejected(new \Error('Rejected Error!')));
+
+                // If we got here, it means no Error is thrown, so fail the test
+                throw new \Exception("Expected \Error to be thrown.");
+            } catch (\Error $error) {
+                if ($error->getMessage() != 'Rejected Error!') {
+                    throw new \Exception("Expected Rejected Error! as message, but got: " . $error->getMessage());
+                }
+            }
+        }
+    }
+
     public function cacheKey($key)
     {
         $cacheKey = [];
         $key = (array)$key;
         ksort($key);
         foreach ($key as $k => $value) {
-            $cacheKey[] = $k.':'.$value;
+            $cacheKey[] = $k . ':' . $value;
         }
 
         return implode(',', $cacheKey);


### PR DESCRIPTION
Fixes #37 

Checks for the existence of the Throwable interface, and allows throwing of Errors while unwrapping the rejectedReason.