### PR TITLE
Add support for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
   - 7.2
   - 7.3
   - nightly
-  - hhvm
 
 branches:
   only:
@@ -27,7 +26,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - if [[ "$TRAVIS_PHP_VERSION" != "5.6" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini || true; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then phpenv config-rm xdebug.ini || true; fi
   - composer selfupdate
 
 install: composer update --prefer-dist --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install: composer update --prefer-source --no-interaction
 script:
   - composer check-platform-reqs
   - bin/phpunit --debug
-  - composer require "friendsofphp/php-cs-fixer:^2.0" && bin/php-cs-fixer fix --diff --dry-run -v
+  - composer require "friendsofphp/php-cs-fixer:^2.16" && bin/php-cs-fixer fix --diff --dry-run -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
   - nightly
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ branches:
 matrix:
   allow_failures:
     - php: nightly
-    - php: 7.3
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - phpenv config-rm xdebug.ini || true
   - composer selfupdate
 
-install: composer update --prefer-dist --no-interaction
+install: composer update --prefer-source --no-interaction
 
 script:
   - composer check-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,6 @@ before_install:
 install: composer update --prefer-dist --no-interaction
 
 script:
+  - composer check-platform-reqs
   - bin/phpunit --debug
   - composer require "friendsofphp/php-cs-fixer:^2.0" && bin/php-cs-fixer fix --diff --dry-run -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ dist: trusty
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -26,14 +23,11 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - if [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then phpenv config-rm xdebug.ini || true; fi
+  - phpenv config-rm xdebug.ini || true
   - composer selfupdate
 
 install: composer update --prefer-dist --no-interaction
 
 script:
-  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then bin/phpunit --debug --coverage-clover build/logs/clover.xml; else bin/phpunit --debug; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then composer require "friendsofphp/php-cs-fixer:^2.0" && bin/php-cs-fixer fix --diff --dry-run -v; fi;
-
-after_success:
-  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then composer require "satooshi/php-coveralls:^1.0" && travis_retry php bin/coveralls -v; fi
+  - bin/phpunit --debug
+  - composer require "friendsofphp/php-cs-fixer:^2.0" && bin/php-cs-fixer fix --diff --dry-run -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ install: composer update --prefer-source --no-interaction
 script:
   - composer check-platform-reqs
   - bin/phpunit --debug
-  - composer require "friendsofphp/php-cs-fixer:^2.16" && bin/php-cs-fixer fix --diff --dry-run -v
+  - if [ "$TRAVIS_PHP_VERSION" != "8.0" ]; then composer require "friendsofphp/php-cs-fixer:^2.16" && bin/php-cs-fixer fix --diff --dry-run -v; fi

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "guzzlehttp/promises": "^1.3.0",
-    "phpunit/phpunit": "^5.7",
+    "phpunit/phpunit": "^7.5",
     "react/promise": "^2.5.0",
     "webonyx/graphql-php": "^0.11.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "guzzlehttp/promises": "^1.3.0",
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^7.5|^8.5",
     "react/promise": "^2.5.0",
     "webonyx/graphql-php": "^14.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "guzzlehttp/promises": "^1.3.0",
-    "phpunit/phpunit": "^7.5",
+    "phpunit/phpunit": "^8.5",
     "react/promise": "^2.5.0",
     "webonyx/graphql-php": "^14.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "guzzlehttp/promises": "^1.3.0",
-    "phpunit/phpunit": "^4.1|^5.1",
+    "phpunit/phpunit": "^5.7",
     "react/promise": "^2.5.0",
     "webonyx/graphql-php": "^0.11.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "guzzlehttp/promises": "^1.3.0",
     "phpunit/phpunit": "^7.5",
     "react/promise": "^2.5.0",
-    "webonyx/graphql-php": "^0.13"
+    "webonyx/graphql-php": "^14.0"
   },
   "suggest": {
     "guzzlehttp/promises": "To use with Guzzle promise",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "guzzlehttp/promises": "^1.3.0",
     "phpunit/phpunit": "^7.5",
     "react/promise": "^2.5.0",
-    "webonyx/graphql-php": "^0.11.0"
+    "webonyx/graphql-php": "^0.13"
   },
   "suggest": {
     "guzzlehttp/promises": "To use with Guzzle promise",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "overblog/promise-adapter": "self.version"
   },
   "require": {
-    "php": "^7.1"
+    "php": "^7.1|^8.0"
   },
   "require-dev": {
     "guzzlehttp/promises": "^1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "overblog/promise-adapter": "self.version"
   },
   "require": {
-    "php": "^5.5|^7.0"
+    "php": "^7.1"
   },
   "require-dev": {
     "guzzlehttp/promises": "^1.3.0",

--- a/lib/promise-adapter/tests/AdapterTest.php
+++ b/lib/promise-adapter/tests/AdapterTest.php
@@ -16,7 +16,7 @@ use Overblog\PromiseAdapter\Adapter\ReactPromiseAdapter;
 use Overblog\PromiseAdapter\Adapter\WebonyxGraphQLSyncPromiseAdapter;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
-class AdapterTest extends \PHPUnit_Framework_TestCase
+class AdapterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider AdapterDataProvider

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
          backupGlobals="false"
          colors="true"
          bootstrap="./vendor/autoload.php"
+         convertDeprecationsToExceptions="false"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="./vendor/autoload.php"

--- a/tests/Functional/Webonyx/GraphQL/Schema.php
+++ b/tests/Functional/Webonyx/GraphQL/Schema.php
@@ -81,6 +81,6 @@ class Schema
             ]
         ]);
 
-        return new \GraphQL\Schema(['query' => $queryType]);
+        return new \GraphQL\Type\Schema(['query' => $queryType]);
     }
 }

--- a/tests/Functional/Webonyx/GraphQL/TestCase.php
+++ b/tests/Functional/Webonyx/GraphQL/TestCase.php
@@ -18,7 +18,7 @@ use GraphQL\Tests\StarWarsData;
 use Overblog\DataLoader\DataLoader;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     private static $fixtures = null;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,7 @@ namespace Overblog\DataLoader\Test;
 use Overblog\PromiseAdapter\Adapter\ReactPromiseAdapter;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var PromiseAdapterInterface

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected static $promiseAdapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         self::$promiseAdapter = new ReactPromiseAdapter();
     }


### PR DESCRIPTION
Resolves #40.

- Minimal PHP version increased to 7.1. (So that supported versions are same as in `webonyx/graphql-php`. Going up to 7.2 would make things easier regarding PHPUnit.)
- Installation on PHP 8 allowed.
- `composer check-platform-reqs` added to build steps
- PHPUnit bumped to `^7.5|^8.5` to support PHP 7.1-8.0
- `webonyx/graphql-php` updated to the current version 14
- `--prefer-source` used for `composer update` as `tests/StarWarsData.php` is no longer part of `webonyx/graphql-php` package. Alternative options would be to create a local copy of the file in this repository or download it from `webonyx/graphql-php` repo with `wget` in `before_install`.
- The current version of `php-cs-fixer` (2.16) used, however, it doesn't allow installation on PHP 8 yet (see  FriendsOfPHP/PHP-CS-Fixer#4702).
- PHPUnit option `convertDeprecationsToExceptions` disabled to deal with deprecated `GraphQL::execute()` (related to #39).

All looks good apart from maybe the most important thing - Travis CI doesn't support PHP 8 yet. PHP 8.0 is available under `nightly` version but contains an ancient version (`PHP 8.0.0-dev (cli) (built: Jan  7 2020 22:28:03) ( ZTS )`) so it can't be trusted.

How do you want me to proceed? Should we wait for Travis CI? Or maybe migrate to Github Actions?