### PR TITLE
Ignore `.phpunit.result.cache` file by Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 composer.phar
 phpunit.xml
 .php_cs.cache
+.phpunit.result.cache


### PR DESCRIPTION
A follow-up to #41. [Since PHPUnit 8.0](https://github.com/sebastianbergmann/phpunit/blob/8.0.0/ChangeLog-8.0.md), result caching is enabled by default and `.phpunit.result.cache` created automatically, so it should be ignored.