### PR TITLE
Exclude files from package dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/lib/promise-adapter/tests export-ignore
+/tests export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php_cs export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
This excludes tests and other unnecessary files from package distribution. Relies on #44 (files deleted there aren't excluded here).