### PR TITLE
Add PHP 8.4 and 8.3 to CI Configuration and Update GitHub Actions Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 2
 
@@ -40,7 +40,7 @@ jobs:
           ini-values: "zend.assertions=1"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 
@@ -48,7 +48,7 @@ jobs:
         run: "vendor/bin/phpunit --coverage-clover=coverage.xml"
 
       - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v2"
+        uses: "actions/upload-artifact@v4"
         with:
           name: "phpunit-${{ matrix.dependencies }}-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
@@ -61,17 +61,17 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 2
 
       - name: "Download coverage files"
-        uses: "actions/download-artifact@v2"
+        uses: "actions/download-artifact@v4"
         with:
           path: "reports"
 
       - name: "Upload to Codecov"
-        uses: "codecov/codecov-action@v1"
+        uses: "codecov/codecov-action@v3"
         with:
           directory: reports
 
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -96,7 +96,7 @@ jobs:
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
 
       - name: "Install php-cs-fixer"
         run: composer require "friendsofphp/php-cs-fixer:^3.23"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,14 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
         dependencies:
           - "lowest"
           - "highest"
+        exclude:
+          - php-version: "8.4"
+            dependencies: "lowest"
 
     steps:
       - name: "Checkout"

--- a/lib/promise-adapter/src/Adapter/GuzzleHttpPromiseAdapter.php
+++ b/lib/promise-adapter/src/Adapter/GuzzleHttpPromiseAdapter.php
@@ -29,7 +29,7 @@ class GuzzleHttpPromiseAdapter implements PromiseAdapterInterface
      *
      * @return Promise
      */
-    public function create(&$resolve = null, &$reject = null, callable $canceller = null)
+    public function create(&$resolve = null, &$reject = null, ?callable $canceller = null)
     {
         $queue = Utils::queue();
         $promise = new Promise([$queue, 'run'], $canceller);

--- a/lib/promise-adapter/src/Adapter/ReactPromiseAdapter.php
+++ b/lib/promise-adapter/src/Adapter/ReactPromiseAdapter.php
@@ -29,7 +29,7 @@ class ReactPromiseAdapter implements PromiseAdapterInterface
      *
      * @return Promise
      */
-    public function create(&$resolve = null, &$reject = null, callable $canceller = null)
+    public function create(&$resolve = null, &$reject = null, ?callable $canceller = null)
     {
         $deferred = new Deferred($canceller);
 

--- a/lib/promise-adapter/src/Adapter/WebonyxGraphQLSyncPromiseAdapter.php
+++ b/lib/promise-adapter/src/Adapter/WebonyxGraphQLSyncPromiseAdapter.php
@@ -30,7 +30,7 @@ class WebonyxGraphQLSyncPromiseAdapter implements PromiseAdapterInterface
      */
     private $webonyxPromiseAdapter;
 
-    public function __construct(SyncPromiseAdapter $webonyxPromiseAdapter = null)
+    public function __construct(?SyncPromiseAdapter $webonyxPromiseAdapter = null)
     {
         $webonyxPromiseAdapter = $webonyxPromiseAdapter?:new SyncPromiseAdapter();
         $this->setWebonyxPromiseAdapter($webonyxPromiseAdapter);

--- a/lib/promise-adapter/src/Adapter/WebonyxGraphQLSyncPromiseAdapter.php
+++ b/lib/promise-adapter/src/Adapter/WebonyxGraphQLSyncPromiseAdapter.php
@@ -55,7 +55,7 @@ class WebonyxGraphQLSyncPromiseAdapter implements PromiseAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function create(&$resolve = null, &$reject = null, callable $canceller = null)
+    public function create(&$resolve = null, &$reject = null, ?callable $canceller = null)
     {
         $promise = $this->webonyxPromiseAdapter->create(function ($res, $rej) use (&$resolve, &$reject) {
             $resolve = $res;

--- a/lib/promise-adapter/src/PromiseAdapterInterface.php
+++ b/lib/promise-adapter/src/PromiseAdapterInterface.php
@@ -25,7 +25,7 @@ interface PromiseAdapterInterface
      *
      * @return TPromise a Promise
      */
-    public function create(&$resolve = null, &$reject = null, callable $canceller = null);
+    public function create(&$resolve = null, &$reject = null, ?callable $canceller = null);
 
     /**
      * Creates a full filed Promise for a value if the value is not a promise.

--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -45,7 +45,7 @@ class DataLoader implements DataLoaderInterface
      */
     private $promiseAdapter;
 
-    public function __construct(callable $batchLoadFn, PromiseAdapterInterface $promiseFactory, Option $options = null)
+    public function __construct(callable $batchLoadFn, PromiseAdapterInterface $promiseFactory, ?Option $options = null)
     {
         $this->batchLoadFn = $batchLoadFn;
         $this->promiseAdapter = $promiseFactory;

--- a/tests/AbuseTest.php
+++ b/tests/AbuseTest.php
@@ -124,7 +124,7 @@ class AbuseTest extends TestCase
      * @param callable $batchLoadFn
      * @return DataLoader
      */
-    private static function idLoader(callable $batchLoadFn = null)
+    private static function idLoader(?callable $batchLoadFn = null)
     {
         if (null === $batchLoadFn) {
             $batchLoadFn = function ($keys) {

--- a/tests/DataLoadTest.php
+++ b/tests/DataLoadTest.php
@@ -894,7 +894,7 @@ class DataLoadTest extends TestCase
         });
     }
 
-    private static function idLoader(Option $options = null, callable $batchLoadFnCallBack = null)
+    private static function idLoader(?Option $options = null, ?callable $batchLoadFnCallBack = null)
     {
         $loadCalls = new \ArrayObject();
         if (null === $batchLoadFnCallBack) {


### PR DESCRIPTION
This pull request provides:

* **PHP 8.4 Compatibility:** Addressed breaking changes before official release.
  * [RFC: Deprecate Implicitly Nullable Types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
    > Status: Implemented
    > Target Version: PHP 8.4
  * Added early support for PHP 8.4 alpha. [PHP 8.4.0alpha1 Release](https://github.com/php/php-src/releases/tag/php-8.4.0alpha1)
* **CI Update:** Included PHP 8.4 and 8.3.
* **GitHub Actions:** Updated to the latest versions.