### PR TITLE
Require PHP 8.2+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ data sources such as databases or web services via batching and caching.
 
 ## Requirements
 
-This library requires PHP >= 7.3 to work.
+This library requires PHP >= 8.2 to work.
 
 ## Getting Started
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "overblog/promise-adapter": "self.version"
   },
   "require": {
-    "php": "^8.1"
+    "php": "^8.2"
   },
   "require-dev": {
     "guzzlehttp/promises": "^1.5.0 || ^2.0.0",


### PR DESCRIPTION
## Summary

- require PHP 8.2 or newer in Composer
- remove PHP 8.1 from the CI matrix
- update the documented minimum PHP version

PHP 8.1 is no longer supported.