### PR TITLE
Support Traversable keys in loadMany

### DIFF
--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -116,6 +116,9 @@ class DataLoader implements DataLoaderInterface
         if (!is_array($keys) && !$keys instanceof \Traversable) {
             throw new \InvalidArgumentException(sprintf('The "%s" method must be called with Array<key> but got: %s.', __METHOD__, gettype($keys)));
         }
+        if ($keys instanceof \Traversable) {
+            $keys = iterator_to_array($keys, false);
+        }
         return $this->getPromiseAdapter()->createAll(array_map(
             function ($key) {
                 return $this->load($key);

--- a/tests/DataLoadTestCase.php
+++ b/tests/DataLoadTestCase.php
@@ -54,6 +54,37 @@ abstract class DataLoadTestCase extends TestCase
     /**
      * @group primary-api
      */
+    public function testSupportsLoadingMultipleKeysFromAnArrayIterator()
+    {
+        list($identityLoader, $loadCalls) = self::idLoader();
+
+        $promiseAll = $identityLoader->loadMany(new \ArrayIterator([2 => 'A', 0 => 'B', 1 => 'C']));
+
+        $this->assertEquals(['A', 'B', 'C'], DataLoader::await($promiseAll));
+        $this->assertEquals([['A', 'B', 'C']], $loadCalls->getArrayCopy());
+    }
+
+    /**
+     * @group primary-api
+     */
+    public function testSupportsLoadingEveryKeyFromAGenerator()
+    {
+        list($identityLoader, $loadCalls) = self::idLoader();
+        $keys = (function () {
+            yield 1 => 'A';
+            yield 1 => 'B';
+            yield 0 => 'C';
+        })();
+
+        $promiseAll = $identityLoader->loadMany($keys);
+
+        $this->assertEquals(['A', 'B', 'C'], DataLoader::await($promiseAll));
+        $this->assertEquals([['A', 'B', 'C']], $loadCalls->getArrayCopy());
+    }
+
+    /**
+     * @group primary-api
+     */
     public function testBatchesMultipleRequests()
     {
         /**


### PR DESCRIPTION
## Summary

- Materialize `Traversable` input before mapping loads.
- Preserve iteration order and repeated iterator keys.

## Motivation

`loadMany()` accepts `Traversable`, but passed it directly to `array_map()`, which only accepts arrays.