### PR TITLE
test: run shared suites with each sync adapter

### DIFF
--- a/tests/AbuseTestCase.php
+++ b/tests/AbuseTestCase.php
@@ -13,10 +13,9 @@ namespace Overblog\DataLoader\Test;
 
 use InvalidArgumentException;
 use Overblog\DataLoader\DataLoader;
-use React\Promise\Promise;
 use RuntimeException;
 
-class AbuseTest extends TestCase
+abstract class AbuseTestCase extends TestCase
 {
     /**
      * @group provides-descriptive-error-messages-for-api-abuse
@@ -34,7 +33,7 @@ class AbuseTest extends TestCase
      */
     public function testLoadFunctionRequiresAKeyWith0()
     {
-        self::assertInstanceOf(Promise::class, self::idLoader()->load(0));
+        self::assertTrue(self::$promiseAdapter->isPromise(self::idLoader()->load(0), true));
     }
 
     /**
@@ -53,7 +52,7 @@ class AbuseTest extends TestCase
      */
     public function testLoadManyFunctionRequiresAListEmptyArrayAccepted()
     {
-        self::assertInstanceOf(Promise::class, self::idLoader()->loadMany([]));
+        self::assertTrue(self::$promiseAdapter->isPromise(self::idLoader()->loadMany([]), true));
     }
 
     /**

--- a/tests/DataLoadTestCase.php
+++ b/tests/DataLoadTestCase.php
@@ -15,7 +15,7 @@ use \Exception;
 use Overblog\DataLoader\DataLoader;
 use Overblog\DataLoader\Option;
 
-class DataLoadTest extends TestCase
+abstract class DataLoadTestCase extends TestCase
 {
     /**
      * @group primary-api
@@ -306,7 +306,7 @@ class DataLoadTest extends TestCase
         $promise1->then(null, function ($error) use (&$caughtError) {
             $caughtError = $error;
         });
-        DataLoader::await();
+        DataLoader::await($promise1, false);
         $this->assertInstanceOf(\Exception::class, $caughtError);
         $this->assertEquals($caughtError->getMessage(), 'Odd: 1');
 
@@ -914,6 +914,7 @@ class DataLoadTest extends TestCase
 
     private function assertInstanceOfPromise($object)
     {
-        $this->assertTrue(self::$promiseAdapter->isPromise($object, true));
+        $adapter = self::$promiseAdapter;
+        $this->assertTrue($adapter->isPromise($object, true));
     }
 }

--- a/tests/DataLoadTestCase.php
+++ b/tests/DataLoadTestCase.php
@@ -815,50 +815,6 @@ abstract class DataLoadTestCase extends TestCase
         $this->assertTrue($secondComplete);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testAwaitShouldReturnTheValueOfFulfilledPromiseWithoutNeedingActiveDataLoaderInstance()
-    {
-        $expectedValue = 'Ok!';
-        $value = DataLoader::await(self::$promiseAdapter->createFulfilled($expectedValue));
-
-        $this->assertEquals($expectedValue, $value);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testAwaitShouldReturnTheRejectReasonOfRejectedPromiseWithoutNeedingActiveDataLoaderInstance()
-    {
-        $expectedException = new \Exception('Rejected!');
-        $exception = DataLoader::await(self::$promiseAdapter->createRejected($expectedException), false);
-
-        $this->assertEquals($expectedException, $exception);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testAwaitShouldThrowTheRejectReasonOfRejectedPromiseWithoutNeedingActiveDataLoaderInstance()
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Rejected!');
-
-        DataLoader::await(self::$promiseAdapter->createRejected(new Exception('Rejected!')));
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testAwaitShouldThrowThrowable()
-    {
-        $this->expectException(\Error::class);
-        $this->expectExceptionMessage('Rejected Error!');
-
-        DataLoader::await(self::$promiseAdapter->createRejected(new \Error('Rejected Error!')));
-    }
-
     public function cacheKey($key)
     {
         $cacheKey = [];

--- a/tests/ReactAbuseTest.php
+++ b/tests/ReactAbuseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the DataLoaderPhp package.
+ *
+ * (c) Overblog <http://github.com/overblog/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Overblog\DataLoader\Test;
+
+use Overblog\PromiseAdapter\Adapter\ReactPromiseAdapter;
+use Overblog\PromiseAdapter\PromiseAdapterInterface;
+
+class ReactAbuseTest extends AbuseTestCase
+{
+    protected function createPromiseAdapter(): PromiseAdapterInterface
+    {
+        return new ReactPromiseAdapter();
+    }
+}

--- a/tests/ReactAbuseTest.php
+++ b/tests/ReactAbuseTest.php
@@ -14,7 +14,7 @@ namespace Overblog\DataLoader\Test;
 use Overblog\PromiseAdapter\Adapter\ReactPromiseAdapter;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
-class ReactAbuseTest extends AbuseTestCase
+final class ReactAbuseTest extends AbuseTestCase
 {
     protected function createPromiseAdapter(): PromiseAdapterInterface
     {

--- a/tests/ReactDataLoadTest.php
+++ b/tests/ReactDataLoadTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the DataLoaderPhp package.
+ *
+ * (c) Overblog <http://github.com/overblog/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Overblog\DataLoader\Test;
+
+use Overblog\PromiseAdapter\Adapter\ReactPromiseAdapter;
+use Overblog\PromiseAdapter\PromiseAdapterInterface;
+
+class ReactDataLoadTest extends DataLoadTestCase
+{
+    protected function createPromiseAdapter(): PromiseAdapterInterface
+    {
+        return new ReactPromiseAdapter();
+    }
+}

--- a/tests/ReactDataLoadTest.php
+++ b/tests/ReactDataLoadTest.php
@@ -11,6 +11,7 @@
 
 namespace Overblog\DataLoader\Test;
 
+use Overblog\DataLoader\DataLoader;
 use Overblog\PromiseAdapter\Adapter\ReactPromiseAdapter;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
@@ -19,5 +20,49 @@ final class ReactDataLoadTest extends DataLoadTestCase
     protected function createPromiseAdapter(): PromiseAdapterInterface
     {
         return new ReactPromiseAdapter();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAwaitShouldReturnTheValueOfFulfilledPromiseWithoutNeedingActiveDataLoaderInstance()
+    {
+        $expectedValue = 'Ok!';
+        $value = DataLoader::await(self::$promiseAdapter->createFulfilled($expectedValue));
+
+        $this->assertEquals($expectedValue, $value);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAwaitShouldReturnTheRejectReasonOfRejectedPromiseWithoutNeedingActiveDataLoaderInstance()
+    {
+        $expectedException = new \Exception('Rejected!');
+        $exception = DataLoader::await(self::$promiseAdapter->createRejected($expectedException), false);
+
+        $this->assertEquals($expectedException, $exception);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAwaitShouldThrowTheRejectReasonOfRejectedPromiseWithoutNeedingActiveDataLoaderInstance()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Rejected!');
+
+        DataLoader::await(self::$promiseAdapter->createRejected(new \Exception('Rejected!')));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAwaitShouldThrowThrowable()
+    {
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Rejected Error!');
+
+        DataLoader::await(self::$promiseAdapter->createRejected(new \Error('Rejected Error!')));
     }
 }

--- a/tests/ReactDataLoadTest.php
+++ b/tests/ReactDataLoadTest.php
@@ -14,7 +14,7 @@ namespace Overblog\DataLoader\Test;
 use Overblog\PromiseAdapter\Adapter\ReactPromiseAdapter;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
-class ReactDataLoadTest extends DataLoadTestCase
+final class ReactDataLoadTest extends DataLoadTestCase
 {
     protected function createPromiseAdapter(): PromiseAdapterInterface
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,7 @@
 
 namespace Overblog\DataLoader\Test;
 
-use Overblog\PromiseAdapter\Adapter\ReactPromiseAdapter;
+use Overblog\DataLoader\DataLoader;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
@@ -23,6 +23,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        self::$promiseAdapter = new ReactPromiseAdapter();
+        self::$promiseAdapter = $this->createPromiseAdapter();
     }
+
+    protected function tearDown(): void
+    {
+        $instances = new \ReflectionProperty(DataLoader::class, 'instances');
+        $instances->setValue([]);
+
+        parent::tearDown();
+    }
+
+    abstract protected function createPromiseAdapter(): PromiseAdapterInterface;
 }

--- a/tests/WebonyxAbuseTest.php
+++ b/tests/WebonyxAbuseTest.php
@@ -14,7 +14,7 @@ namespace Overblog\DataLoader\Test;
 use Overblog\PromiseAdapter\Adapter\WebonyxGraphQLSyncPromiseAdapter;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
-class WebonyxAbuseTest extends AbuseTestCase
+final class WebonyxAbuseTest extends AbuseTestCase
 {
     protected function createPromiseAdapter(): PromiseAdapterInterface
     {

--- a/tests/WebonyxAbuseTest.php
+++ b/tests/WebonyxAbuseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the DataLoaderPhp package.
+ *
+ * (c) Overblog <http://github.com/overblog/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Overblog\DataLoader\Test;
+
+use Overblog\PromiseAdapter\Adapter\WebonyxGraphQLSyncPromiseAdapter;
+use Overblog\PromiseAdapter\PromiseAdapterInterface;
+
+class WebonyxAbuseTest extends AbuseTestCase
+{
+    protected function createPromiseAdapter(): PromiseAdapterInterface
+    {
+        return new WebonyxGraphQLSyncPromiseAdapter();
+    }
+}

--- a/tests/WebonyxDataLoadTest.php
+++ b/tests/WebonyxDataLoadTest.php
@@ -14,7 +14,7 @@ namespace Overblog\DataLoader\Test;
 use Overblog\PromiseAdapter\Adapter\WebonyxGraphQLSyncPromiseAdapter;
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
-class WebonyxDataLoadTest extends DataLoadTestCase
+final class WebonyxDataLoadTest extends DataLoadTestCase
 {
     protected function createPromiseAdapter(): PromiseAdapterInterface
     {

--- a/tests/WebonyxDataLoadTest.php
+++ b/tests/WebonyxDataLoadTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the DataLoaderPhp package.
+ *
+ * (c) Overblog <http://github.com/overblog/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Overblog\DataLoader\Test;
+
+use Overblog\PromiseAdapter\Adapter\WebonyxGraphQLSyncPromiseAdapter;
+use Overblog\PromiseAdapter\PromiseAdapterInterface;
+
+class WebonyxDataLoadTest extends DataLoadTestCase
+{
+    protected function createPromiseAdapter(): PromiseAdapterInterface
+    {
+        return new WebonyxGraphQLSyncPromiseAdapter();
+    }
+}


### PR DESCRIPTION
## Summary

- Run the shared DataLoader and API-abuse suites with React and Webonyx adapters.
- Keep common behavior in abstract `*TestCase` suites and concrete adapter suites final.
- Keep loader-free static await cases in the React suite because Webonyx needs an adapter instance to run its queue.
- Replace React-specific assertions with adapter contract assertions.
- Reset retained loader instances between tests so adapter state cannot leak across the matrix.

## Motivation

The main behavior suites only exercised the React adapter. Running the shared contract through each synchronous adapter exposes adapter-specific behavior without duplicating test cases.