### PR TITLE
Bump actions/download-artifact from 4 to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 2
 
       - name: "Download coverage files"
-        uses: "actions/download-artifact@v4"
+        uses: "actions/download-artifact@v8"
         with:
           path: "reports"
 


### PR DESCRIPTION
## Summary

- Upgrade `actions/download-artifact` from v4 to v8.
- Use the current Node.js 24 action runtime.
- Enable v8 digest mismatch failures by default.

## Motivation

GitHub now warns that the Node.js 20 runtime used by v4 is deprecated and forces it to run on Node.js 24.