### PR TITLE
Reject synchronous batch callback failures

### DIFF
--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -91,6 +91,11 @@ class DataLoader implements DataLoaderInterface
             'promise' => $promise,
         ];
 
+        // If caching, cache this promise before it may be dispatched.
+        if ($shouldCache) {
+            $this->promiseCache->set($cacheKey, $promise);
+        }
+
         // Determine if a dispatch of this queue should be scheduled.
         // A single dispatch should be scheduled per queue at the time when the
         // queue changes from "empty" to "full".
@@ -99,10 +104,6 @@ class DataLoader implements DataLoaderInterface
                 // Otherwise dispatch the (queue of one) immediately.
                 $this->dispatchQueue();
             }
-        }
-        // If caching, cache this promise.
-        if ($shouldCache) {
-            $this->promiseCache->set($cacheKey, $promise);
         }
 
         return $promise;
@@ -331,7 +332,13 @@ class DataLoader implements DataLoaderInterface
 
         // Call the provided batchLoadFn for this loader with the loader queue's keys.
         $batchLoadFn = $this->batchLoadFn;
-        $batchPromise = $batchLoadFn($keys);
+        try {
+            $batchPromise = $batchLoadFn($keys);
+        } catch (\Throwable $error) {
+            $this->failedDispatch($queue, $error);
+
+            return;
+        }
 
         // Assert the expected response from batchLoadFn
         if (!$batchPromise || !is_callable([$batchPromise, 'then'])) {

--- a/tests/DataLoadTestCase.php
+++ b/tests/DataLoadTestCase.php
@@ -558,19 +558,8 @@ abstract class DataLoadTestCase extends TestCase
         $promise1 = $loader->load(1);
         $promise2 = $loader->load(2);
 
-        $rejectedReason1 = null;
-        $promise1->then(null, function ($reason) use (&$rejectedReason1) {
-            $rejectedReason1 = $reason;
-        });
-        $rejectedReason2 = null;
-        $promise2->then(null, function ($reason) use (&$rejectedReason2) {
-            $rejectedReason2 = $reason;
-        });
-
-        DataLoader::await();
-
-        $this->assertSame($throwable, $rejectedReason1);
-        $this->assertSame($throwable, $rejectedReason2);
+        $this->assertSame($throwable, DataLoader::await($promise1, false));
+        $this->assertSame($throwable, DataLoader::await($promise2, false));
 
         $this->assertEquals(
             [1, 2],
@@ -590,12 +579,7 @@ abstract class DataLoadTestCase extends TestCase
             return self::$promiseAdapter->createFulfilled($keys);
         });
 
-        $rejectedReason = null;
-        $loader->load(1)->then(null, function ($reason) use (&$rejectedReason) {
-            $rejectedReason = $reason;
-        });
-
-        $this->assertInstanceOf(\Exception::class, $rejectedReason);
+        $this->assertInstanceOf(\Exception::class, DataLoader::await($loader->load(1), false));
         $this->assertEquals(1, DataLoader::await($loader->load(1)));
         $this->assertEquals([[1], [1]], $loadCalls->getArrayCopy());
     }

--- a/tests/DataLoadTestCase.php
+++ b/tests/DataLoadTestCase.php
@@ -542,6 +542,73 @@ abstract class DataLoadTestCase extends TestCase
     }
 
     /**
+     * @dataProvider provideSynchronousBatchThrowable
+     */
+    public function testPropagatesSynchronousBatchThrowableToAllLoadsAndAllowsRetry(\Throwable $throwable)
+    {
+        $attempt = 0;
+        list($loader, $loadCalls) = self::idLoader(null, function ($keys) use (&$attempt, $throwable) {
+            if (0 === $attempt++) {
+                throw $throwable;
+            }
+
+            return self::$promiseAdapter->createFulfilled($keys);
+        });
+
+        $promise1 = $loader->load(1);
+        $promise2 = $loader->load(2);
+
+        $rejectedReason1 = null;
+        $promise1->then(null, function ($reason) use (&$rejectedReason1) {
+            $rejectedReason1 = $reason;
+        });
+        $rejectedReason2 = null;
+        $promise2->then(null, function ($reason) use (&$rejectedReason2) {
+            $rejectedReason2 = $reason;
+        });
+
+        DataLoader::await();
+
+        $this->assertSame($throwable, $rejectedReason1);
+        $this->assertSame($throwable, $rejectedReason2);
+
+        $this->assertEquals(
+            [1, 2],
+            DataLoader::await(self::$promiseAdapter->createAll([$loader->load(1), $loader->load(2)]))
+        );
+        $this->assertEquals([[1, 2], [1, 2]], $loadCalls->getArrayCopy());
+    }
+
+    public function testDoesNotCacheSynchronousBatchFailureWhenBatchingIsDisabled()
+    {
+        $attempt = 0;
+        list($loader, $loadCalls) = self::idLoader(new Option(['batch' => false]), function ($keys) use (&$attempt) {
+            if (0 === $attempt++) {
+                throw new \Exception('Synchronous batch exception');
+            }
+
+            return self::$promiseAdapter->createFulfilled($keys);
+        });
+
+        $rejectedReason = null;
+        $loader->load(1)->then(null, function ($reason) use (&$rejectedReason) {
+            $rejectedReason = $reason;
+        });
+
+        $this->assertInstanceOf(\Exception::class, $rejectedReason);
+        $this->assertEquals(1, DataLoader::await($loader->load(1)));
+        $this->assertEquals([[1], [1]], $loadCalls->getArrayCopy());
+    }
+
+    public static function provideSynchronousBatchThrowable()
+    {
+        return [
+            'exception' => [new \Exception('Synchronous batch exception')],
+            'error' => [new \Error('Synchronous batch error')],
+        ];
+    }
+
+    /**
      * @group accepts-any-kind-of-key
      */
     public function testAcceptsObjectsAsKeys()


### PR DESCRIPTION
## Summary

- Convert synchronous batch callback throws into rejected load promises.
- Reject every queued load through the existing whole-batch failure path.
- Cache promises before immediate dispatch so failed non-batched loads can retry.

## Motivation

A callback that throws before returning a promise escapes dispatch and can leave queued promises unresolved or cache a failed immediate load. The current `master` Throwable contract handles both `Exception` and `Error` consistently.