### PR TITLE
feat(typing): preserve adapter promise types

### DIFF
--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -13,6 +13,11 @@ namespace Overblog\DataLoader;
 
 use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
+/**
+ * @template TPromise
+ *
+ * @implements DataLoaderInterface<TPromise>
+ */
 class DataLoader implements DataLoaderInterface
 {
     /**
@@ -51,10 +56,13 @@ class DataLoader implements DataLoaderInterface
     private static $promiseAdapters;
 
     /**
-     * @var PromiseAdapterInterface
+     * @var PromiseAdapterInterface<TPromise>
      */
     private $promiseAdapter;
 
+    /**
+     * @param PromiseAdapterInterface<TPromise> $promiseFactory
+     */
     public function __construct(callable $batchLoadFn, PromiseAdapterInterface $promiseFactory, ?Option $options = null)
     {
         $this->batchLoadFn = $batchLoadFn;
@@ -65,9 +73,7 @@ class DataLoader implements DataLoaderInterface
         self::$instances[$this] = null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    /** @return TPromise */
     public function load($key)
     {
         $this->checkKey($key, __METHOD__);
@@ -122,9 +128,7 @@ class DataLoader implements DataLoaderInterface
         return $promise;
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    /** @return TPromise */
     public function loadMany($keys)
     {
         if (!is_array($keys) && !$keys instanceof \Traversable) {
@@ -219,6 +223,7 @@ class DataLoader implements DataLoaderInterface
         }
     }
 
+    /** @return PromiseAdapterInterface<TPromise> */
     protected function getPromiseAdapter()
     {
         return $this->promiseAdapter;

--- a/src/DataLoaderInterface.php
+++ b/src/DataLoaderInterface.php
@@ -11,6 +11,9 @@
 
 namespace Overblog\DataLoader;
 
+/**
+ * @template TPromise
+ */
 interface DataLoaderInterface
 {
     /**
@@ -18,7 +21,7 @@ interface DataLoaderInterface
      *
      * @param mixed $key
      *
-     * @return mixed return a Promise
+     * @return TPromise a Promise
      */
     public function load($key);
 
@@ -35,7 +38,7 @@ interface DataLoaderInterface
      *     ]);
      * @param array $keys
      *
-     * @return mixed return a Promise
+     * @return TPromise a Promise
      */
     public function loadMany($keys);
 


### PR DESCRIPTION
Summary:
- make DataLoaderInterface generic over its adapter promise type
- propagate the type through DataLoader construction, loading, and adapter access

Known limitation:
- a CacheMap can be shared across different adapters, so a cache hit can return a foreign promise implementation. The generic contract assumes cache maps are not shared across incompatible adapters.